### PR TITLE
Add `top_k` Function for `double` and `float` Data Types

### DIFF
--- a/include/rindow/matlib.h
+++ b/include/rindow/matlib.h
@@ -217,6 +217,8 @@ RINDOW_FUNC_DECL int32_t rindow_matlib_s_onehot(int32_t dtype, int32_t m, int32_
 RINDOW_FUNC_DECL int32_t rindow_matlib_d_onehot(int32_t dtype, int32_t m, int32_t n, void *x, int32_t incX, double alpha, double *a, int32_t ldA);
 RINDOW_FUNC_DECL void rindow_matlib_s_softmax(int32_t m, int32_t n, float *a, int32_t ldA);
 RINDOW_FUNC_DECL void rindow_matlib_d_softmax(int32_t m, int32_t n, double *a, int32_t ldA);
+RINDOW_FUNC_DECL void rindow_matlib_s_top_k(int32_t m, int32_t n, float *a, int32_t ldA, int32_t k, int32_t sorted, float *top_values, int32_t *top_indices);
+RINDOW_FUNC_DECL void rindow_matlib_d_top_k(int32_t m, int32_t n, double *a, int32_t ldA, int32_t k, int32_t sorted, double *top_values, int32_t *top_indices);
 RINDOW_FUNC_DECL void rindow_matlib_s_equal(int32_t n, float *x, int32_t incX, float *y, int32_t incY);
 RINDOW_FUNC_DECL void rindow_matlib_d_equal(int32_t n, double *x, int32_t incX, double *y, int32_t incY);
 RINDOW_FUNC_DECL void rindow_matlib_i_equal(int32_t dtype, int32_t n, void *x, int32_t incX, void *y, int32_t incY);

--- a/include/rindow/matlib.h
+++ b/include/rindow/matlib.h
@@ -217,8 +217,8 @@ RINDOW_FUNC_DECL int32_t rindow_matlib_s_onehot(int32_t dtype, int32_t m, int32_
 RINDOW_FUNC_DECL int32_t rindow_matlib_d_onehot(int32_t dtype, int32_t m, int32_t n, void *x, int32_t incX, double alpha, double *a, int32_t ldA);
 RINDOW_FUNC_DECL void rindow_matlib_s_softmax(int32_t m, int32_t n, float *a, int32_t ldA);
 RINDOW_FUNC_DECL void rindow_matlib_d_softmax(int32_t m, int32_t n, double *a, int32_t ldA);
-RINDOW_FUNC_DECL void rindow_matlib_s_top_k(int32_t m, int32_t n, float *a, int32_t ldA, int32_t k, float *top_values, int32_t *top_indices);
-RINDOW_FUNC_DECL void rindow_matlib_d_top_k(int32_t m, int32_t n, double *a, int32_t ldA, int32_t k, double *top_values, int32_t *top_indices);
+RINDOW_FUNC_DECL void rindow_matlib_s_top_k(int32_t m, int32_t n, float *a, int32_t ldA, int32_t k, int32_t sorted, float *top_values, int32_t *top_indices);
+RINDOW_FUNC_DECL void rindow_matlib_d_top_k(int32_t m, int32_t n, double *a, int32_t ldA, int32_t k, int32_t sorted, double *top_values, int32_t *top_indices);
 RINDOW_FUNC_DECL void rindow_matlib_s_equal(int32_t n, float *x, int32_t incX, float *y, int32_t incY);
 RINDOW_FUNC_DECL void rindow_matlib_d_equal(int32_t n, double *x, int32_t incX, double *y, int32_t incY);
 RINDOW_FUNC_DECL void rindow_matlib_i_equal(int32_t dtype, int32_t n, void *x, int32_t incX, void *y, int32_t incY);

--- a/include/rindow/matlib.h
+++ b/include/rindow/matlib.h
@@ -217,8 +217,8 @@ RINDOW_FUNC_DECL int32_t rindow_matlib_s_onehot(int32_t dtype, int32_t m, int32_
 RINDOW_FUNC_DECL int32_t rindow_matlib_d_onehot(int32_t dtype, int32_t m, int32_t n, void *x, int32_t incX, double alpha, double *a, int32_t ldA);
 RINDOW_FUNC_DECL void rindow_matlib_s_softmax(int32_t m, int32_t n, float *a, int32_t ldA);
 RINDOW_FUNC_DECL void rindow_matlib_d_softmax(int32_t m, int32_t n, double *a, int32_t ldA);
-RINDOW_FUNC_DECL void rindow_matlib_s_top_k(int32_t m, int32_t n, float *a, int32_t ldA, int32_t k, int32_t sorted, float *top_values, int32_t *top_indices);
-RINDOW_FUNC_DECL void rindow_matlib_d_top_k(int32_t m, int32_t n, double *a, int32_t ldA, int32_t k, int32_t sorted, double *top_values, int32_t *top_indices);
+RINDOW_FUNC_DECL void rindow_matlib_s_top_k(int32_t m, int32_t n, float *a, int32_t ldA, int32_t k, float *top_values, int32_t *top_indices);
+RINDOW_FUNC_DECL void rindow_matlib_d_top_k(int32_t m, int32_t n, double *a, int32_t ldA, int32_t k, double *top_values, int32_t *top_indices);
 RINDOW_FUNC_DECL void rindow_matlib_s_equal(int32_t n, float *x, int32_t incX, float *y, int32_t incY);
 RINDOW_FUNC_DECL void rindow_matlib_d_equal(int32_t n, double *x, int32_t incX, double *y, int32_t incY);
 RINDOW_FUNC_DECL void rindow_matlib_i_equal(int32_t dtype, int32_t n, void *x, int32_t incX, void *y, int32_t incY);

--- a/src/top_k.c
+++ b/src/top_k.c
@@ -116,7 +116,7 @@ void rindow_matlib_d_top_k(
         int32_t j;
         #pragma omp parallel for
         for (j = 0; j < m; j++) {
-            RINDOW_MATLIB_SORT_TOP_K(double, DoubleIndexPair, temp_array, j, k, top_values, top_indices, compare_double);
+            RINDOW_MATLIB_SORT_TOP_K(double, DoubleIndexPair, temp_sorted_array, j, k, top_values, top_indices, compare_double);
         }
 
         free(temp_sorted_array);

--- a/src/top_k.c
+++ b/src/top_k.c
@@ -66,8 +66,9 @@ void rindow_matlib_s_top_k(
 {
     FloatIndexPair *temp_array = (FloatIndexPair *)malloc(n * sizeof(FloatIndexPair));
 
+    int32_t i;
     #pragma omp parallel for
-    for (int i = 0; i < m; i++) {
+    for (i = 0; i < m; i++) {
         RINDOW_MATLIB_GET_TOP_K(float, FloatIndexPair, temp_array, i, a, ldA, n, k, top_values, top_indices, compare_float);
     }
 
@@ -77,9 +78,10 @@ void rindow_matlib_s_top_k(
     if (sorted) {
         FloatIndexPair *temp_sorted_array = (FloatIndexPair *)malloc(k * sizeof(FloatIndexPair));
        
+        int32_t j;
         #pragma omp parallel for
-        for (int i = 0; i < m; i++) {
-            RINDOW_MATLIB_SORT_TOP_K(float, FloatIndexPair, temp_sorted_array, i, k, top_values, top_indices, compare_float);
+        for (j = 0; j < m; j++) {
+            RINDOW_MATLIB_SORT_TOP_K(float, FloatIndexPair, temp_sorted_array, j, k, top_values, top_indices, compare_float);
         }
 
         free(temp_sorted_array);
@@ -99,8 +101,9 @@ void rindow_matlib_d_top_k(
 {
     DoubleIndexPair *temp_array = (DoubleIndexPair *)malloc(n * sizeof(DoubleIndexPair));
    
+    int32_t i;
     #pragma omp parallel for
-    for (int i = 0; i < m; i++) {
+    for (i = 0; i < m; i++) {
         RINDOW_MATLIB_GET_TOP_K(double, DoubleIndexPair, temp_array, i, a, ldA, n, k, top_values, top_indices, compare_double);
     }
 
@@ -110,9 +113,10 @@ void rindow_matlib_d_top_k(
     if (sorted) {
         DoubleIndexPair *temp_sorted_array = (DoubleIndexPair *)malloc(k * sizeof(DoubleIndexPair));
         
+        int32_t j;
         #pragma omp parallel for
-        for (int i = 0; i < m; i++) {
-            RINDOW_MATLIB_SORT_TOP_K(double, DoubleIndexPair, temp_array, i, k, top_values, top_indices, compare_double);
+        for (j = 0; j < m; j++) {
+            RINDOW_MATLIB_SORT_TOP_K(double, DoubleIndexPair, temp_array, j, k, top_values, top_indices, compare_double);
         }
 
         free(temp_sorted_array);

--- a/src/top_k.c
+++ b/src/top_k.c
@@ -16,20 +16,6 @@
         top_indices[i * k + j] = temp[j].index; \
     }
 
-#define RINDOW_MATLIB_SORT_TOP_K(data_type, pair_type, temp, i, k, top_values, top_indices, compare_func) \
-    /* Initialize temp with top K values and indices */ \
-    for (int j = 0; j < k; j++) { \
-        temp[j].value = top_values[i * k + j]; \
-        temp[j].index = top_indices[i * k + j]; \
-    } \
-    /* Sort temp array based on values in descending order */ \
-    qsort(temp, k, sizeof(pair_type), compare_func); \
-    /* Copy back the sorted values and indices */ \
-    for (int j = 0; j < k; j++) { \
-        top_values[i * k + j] = temp[j].value; \
-        top_indices[i * k + j] = temp[j].index; \
-    }
-
 typedef struct {
     float value;
     int32_t index;
@@ -59,7 +45,6 @@ void rindow_matlib_s_top_k(
     float *a, // Input data (array of vectors)
     int32_t ldA, // Leading dimension of the input (usually equal to n)
     int32_t k, // Number of top elements to find
-    int32_t sorted, // Whether to return sorted values and indices
     float *top_values, // Output array for the top K values
     int32_t *top_indices // Output array for the indices of the top K values
 )
@@ -73,19 +58,6 @@ void rindow_matlib_s_top_k(
     }
 
     free(temp_array);
-
-    // If sorting is required, sort the top K using RINDOW_MATLIB_SORT_TOP_K macro
-    if (sorted) {
-        FloatIndexPair *temp_sorted_array = (FloatIndexPair *)malloc(k * sizeof(FloatIndexPair));
-       
-        int32_t j;
-        #pragma omp parallel for
-        for (j = 0; j < m; j++) {
-            RINDOW_MATLIB_SORT_TOP_K(float, FloatIndexPair, temp_sorted_array, j, k, top_values, top_indices, compare_float);
-        }
-
-        free(temp_sorted_array);
-    }
 }
 
 void rindow_matlib_d_top_k(
@@ -94,7 +66,6 @@ void rindow_matlib_d_top_k(
     double *a, // Input data (array of vectors)
     int32_t ldA, // Leading dimension of the input (usually equal to n)
     int32_t k, // Number of top elements to find
-    int32_t sorted, // Whether to return sorted values and indices
     double *top_values, // Output array for the top K values
     int32_t *top_indices // Output array for the indices of the top K values
 )
@@ -108,19 +79,6 @@ void rindow_matlib_d_top_k(
     }
 
     free(temp_array);
-
-    // If sorting is required, sort the top K using RINDOW_MATLIB_SORT_TOP_K macro
-    if (sorted) {
-        DoubleIndexPair *temp_sorted_array = (DoubleIndexPair *)malloc(k * sizeof(DoubleIndexPair));
-        
-        int32_t j;
-        #pragma omp parallel for
-        for (j = 0; j < m; j++) {
-            RINDOW_MATLIB_SORT_TOP_K(double, DoubleIndexPair, temp_sorted_array, j, k, top_values, top_indices, compare_double);
-        }
-
-        free(temp_sorted_array);
-    }
 }
 
 

--- a/src/top_k.c
+++ b/src/top_k.c
@@ -46,13 +46,13 @@ typedef struct {
     int32_t index;
 } DoubleIndexPair;
 
-int compare_float(const void *a, const void *b) {
+static int compare_float(const void *a, const void *b) {
     const FloatIndexPair *pairA = (const FloatIndexPair *)a;
     const FloatIndexPair *pairB = (const FloatIndexPair *)b;
     return (pairB->value > pairA->value) - (pairB->value < pairA->value);
 }
 
-int compare_double(const void *a, const void *b) {
+static int compare_double(const void *a, const void *b) {
     const DoubleIndexPair *pairA = (const DoubleIndexPair *)a;
     const DoubleIndexPair *pairB = (const DoubleIndexPair *)b;
     return (pairB->value > pairA->value) - (pairB->value < pairA->value);

--- a/src/top_k.c
+++ b/src/top_k.c
@@ -1,0 +1,114 @@
+#include "rindow/matlib.h"
+#include <math.h>
+#include "common.h"
+
+#define RINDOW_MATLIB_GET_TOP_K(data_type, pair_type, i, a, ldA, n, k, top_values, top_indices, compare_func) \
+    pair_type *temp = (pair_type *)malloc(n * sizeof(pair_type)); \
+    /* Initialize temp with all elements and their indices */ \
+    for (int j = 0; j < n; j++) { \
+        temp[j].value = a[i * ldA + j]; \
+        temp[j].index = j; \
+    } \
+    /* Sort temp array based on values in descending order */ \
+    qsort(temp, n, sizeof(pair_type), compare_func); \
+    /* Select the top K items */ \
+    for (int j = 0; j < k; j++) { \
+        top_values[i * k + j] = temp[j].value; \
+        top_indices[i * k + j] = temp[j].index; \
+    } \
+    /* Free the allocated memory */ \
+    free(temp);
+
+#define RINDOW_MATLIB_SORT_TOP_K(data_type, pair_type, i, k, top_values, top_indices, compare_func) \
+    pair_type *temp = (pair_type *)malloc(k * sizeof(pair_type)); \
+    /* Initialize temp with top K values and indices */ \
+    for (int j = 0; j < k; j++) { \
+        temp[j].value = top_values[i * k + j]; \
+        temp[j].index = top_indices[i * k + j]; \
+    } \
+    /* Sort temp array based on values in descending order */ \
+    qsort(temp, k, sizeof(pair_type), compare_func); \
+    /* Copy back the sorted values and indices */ \
+    for (int j = 0; j < k; j++) { \
+        top_values[i * k + j] = temp[j].value; \
+        top_indices[i * k + j] = temp[j].index; \
+    } \
+    /* Free the allocated memory */ \
+    free(temp);
+
+typedef struct {
+    float value;
+    int32_t index;
+} FloatIndexPair;
+
+typedef struct {
+    double value;
+    int32_t index;
+} DoubleIndexPair;
+
+int compare_float(const void *a, const void *b) {
+    const FloatIndexPair *pairA = (const FloatIndexPair *)a;
+    const FloatIndexPair *pairB = (const FloatIndexPair *)b;
+    return (pairB->value > pairA->value) - (pairB->value < pairA->value);
+}
+
+int compare_double(const void *a, const void *b) {
+    const DoubleIndexPair *pairA = (const DoubleIndexPair *)a;
+    const DoubleIndexPair *pairB = (const DoubleIndexPair *)b;
+    return (pairB->value > pairA->value) - (pairB->value < pairA->value);
+}
+
+
+void rindow_matlib_s_top_k(
+    int32_t m, // Number of rows or vectors
+    int32_t n, // Number of columns or elements in each vector
+    float *a, // Input data (array of vectors)
+    int32_t ldA, // Leading dimension of the input (usually equal to n)
+    int32_t k, // Number of top elements to find
+    int32_t sorted, // Whether to return sorted values and indices
+    float *top_values, // Output array for the top K values
+    int32_t *top_indices // Output array for the indices of the top K values
+)
+{
+    // Calculate top K for each row using RINDOW_MATLIB_GET_TOP_K macro
+    #pragma omp parallel for
+    for (int i = 0; i < m; i++) {
+        RINDOW_MATLIB_GET_TOP_K(float, FloatIndexPair, i, a, ldA, n, k, top_values, top_indices, compare_float);
+    }
+
+    // If sorting is required, sort the top K using RINDOW_MATLIB_SORT_TOP_K macro
+    if (sorted) {
+        #pragma omp parallel for
+        for (int i = 0; i < m; i++) {
+            RINDOW_MATLIB_SORT_TOP_K(float, FloatIndexPair, i, k, top_values, top_indices, compare_float);
+        }
+    }
+}
+
+void rindow_matlib_d_top_k(
+    int32_t m, // Number of rows or vectors
+    int32_t n, // Number of columns or elements in each vector
+    double *a, // Input data (array of vectors)
+    int32_t ldA, // Leading dimension of the input (usually equal to n)
+    int32_t k, // Number of top elements to find
+    int32_t sorted, // Whether to return sorted values and indices
+    double *top_values, // Output array for the top K values
+    int32_t *top_indices // Output array for the indices of the top K values
+)
+{
+    // Calculate top K for each row using RINDOW_MATLIB_GET_TOP_K macro
+    #pragma omp parallel for
+    for (int i = 0; i < m; i++) {
+        RINDOW_MATLIB_GET_TOP_K(double, DoubleIndexPair, i, a, ldA, n, k, top_values, top_indices, compare_double);
+    }
+
+    // If sorting is required, sort the top K using RINDOW_MATLIB_SORT_TOP_K macro
+    if (sorted) {
+        #pragma omp parallel for
+        for (int i = 0; i < m; i++) {
+            RINDOW_MATLIB_SORT_TOP_K(double, DoubleIndexPair, i, k, top_values, top_indices, compare_double);
+        }
+    }
+}
+
+

--- a/tests/TopKTest.cpp
+++ b/tests/TopKTest.cpp
@@ -1,0 +1,70 @@
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+#include "rindow/matlib.h"
+#include "Utils.h"
+
+using testing::ContainerEq;
+using RindowTest::Utils;
+
+namespace {
+
+template <typename T>
+class TopKTest : public ::testing::Test {
+protected:
+    virtual void test_matlib_top_k(
+        int32_t m, int32_t n, float *a, int32_t ldA, 
+        int32_t k, int32_t sorted,
+        float *top_values, int32_t *top_indices
+    ) {
+        rindow_matlib_s_top_k(m, n, a, ldA, k, sorted, top_values, top_indices);
+    }
+
+    virtual void test_matlib_top_k(
+        int32_t m, int32_t n, double *a, int32_t ldA, 
+        int32_t k, int32_t sorted,
+        double *top_values, int32_t *top_indices
+    ) {
+        rindow_matlib_d_top_k(m, n, a, ldA, k, sorted, top_values, top_indices);
+    }
+};
+
+typedef ::testing::Types<float, double> TestTypes;
+TYPED_TEST_SUITE(TopKTest, TestTypes);
+
+TYPED_TEST(TopKTest, normal) {
+    const int32_t m = 2; // Number of rows or vectors
+    const int32_t n = 5; // Number of columns or elements in each vector
+    const int32_t ldA = n; // Leading dimension of the input
+    const int32_t k = 3; // Number of top elements to find
+    const int32_t sorted = 1; // Return sorted values and indices
+
+    TypeParam a[m][n] = {
+        {1.0, 2.0, 3.0, 4.0, 5.0},
+        {5.0, 4.0, 3.0, 2.0, 1.0}
+    };
+
+    TypeParam top_values[m][k];
+    int32_t top_indices[m][k];
+
+    this->test_matlib_top_k(m, n, (TypeParam*)a, ldA, k, sorted, (TypeParam*)top_values, (int32_t*)top_indices);
+
+    // Expected results
+    TypeParam expected_values[m][k] = {
+        {5.0, 4.0, 3.0},
+        {5.0, 4.0, 3.0}
+    };
+
+    int32_t expected_indices[m][k] = {
+        {4, 3, 2},
+        {0, 1, 2}
+    };
+
+    // Compare the top K values and indices with expected results
+    for (int32_t i = 0; i < m; i++) {
+        EXPECT_TRUE(Utils::isclose(k, (TypeParam*)expected_values[i], top_values[i]));
+        EXPECT_EQ(std::vector<int32_t>(expected_indices[i], expected_indices[i] + k),
+                  std::vector<int32_t>(top_indices[i], top_indices[i] + k));
+    }
+}
+
+} // namespace

--- a/tests/TopKTest.cpp
+++ b/tests/TopKTest.cpp
@@ -13,18 +13,18 @@ class TopKTest : public ::testing::Test {
 protected:
     virtual void test_matlib_top_k(
         int32_t m, int32_t n, float *a, 
-        int32_t ldA, int32_t k,
+        int32_t ldA, int32_t k, int32_t sorted,
         float *top_values, int32_t *top_indices
     ) {
-        rindow_matlib_s_top_k(m, n, a, ldA, k, top_values, top_indices);
+        rindow_matlib_s_top_k(m, n, a, ldA, k, sorted, top_values, top_indices);
     }
 
     virtual void test_matlib_top_k(
         int32_t m, int32_t n, double *a, 
-        int32_t ldA, int32_t k,
+        int32_t ldA, int32_t k, int32_t sorted,
         double *top_values, int32_t *top_indices
     ) {
-        rindow_matlib_d_top_k(m, n, a, ldA, k, top_values, top_indices);
+        rindow_matlib_d_top_k(m, n, a, ldA, k, sorted, top_values, top_indices);
     }
 };
 
@@ -36,6 +36,7 @@ TYPED_TEST(TopKTest, normal) {
     const int32_t n = 5; // Number of columns or elements in each vector
     const int32_t ldA = n; // Leading dimension of the input
     const int32_t k = 3; // Number of top elements to find
+    const int32_t sorted = 1; // Whether to return sorted values and indices
 
     TypeParam a[m][n] = {
         {1.0, 2.0, 3.0, 4.0, 5.0},
@@ -45,7 +46,7 @@ TYPED_TEST(TopKTest, normal) {
     TypeParam top_values[m][k];
     int32_t top_indices[m][k];
 
-    this->test_matlib_top_k(m, n, (TypeParam*)a, ldA, k, (TypeParam*)top_values, (int32_t*)top_indices);
+    this->test_matlib_top_k(m, n, (TypeParam*)a, ldA, k, sorted, (TypeParam*)top_values, (int32_t*)top_indices);
 
     // Expected results
     TypeParam expected_values[m][k] = {
@@ -57,6 +58,7 @@ TYPED_TEST(TopKTest, normal) {
         {4, 3, 2},
         {0, 1, 2}
     };
+    
 
     // Compare the top K values and indices with expected results
     for (int32_t i = 0; i < m; i++) {
@@ -65,5 +67,4 @@ TYPED_TEST(TopKTest, normal) {
                   std::vector<int32_t>(top_indices[i], top_indices[i] + k));
     }
 }
-
 } // namespace

--- a/tests/TopKTest.cpp
+++ b/tests/TopKTest.cpp
@@ -12,19 +12,19 @@ template <typename T>
 class TopKTest : public ::testing::Test {
 protected:
     virtual void test_matlib_top_k(
-        int32_t m, int32_t n, float *a, int32_t ldA, 
-        int32_t k, int32_t sorted,
+        int32_t m, int32_t n, float *a, 
+        int32_t ldA, int32_t k,
         float *top_values, int32_t *top_indices
     ) {
-        rindow_matlib_s_top_k(m, n, a, ldA, k, sorted, top_values, top_indices);
+        rindow_matlib_s_top_k(m, n, a, ldA, k, top_values, top_indices);
     }
 
     virtual void test_matlib_top_k(
-        int32_t m, int32_t n, double *a, int32_t ldA, 
-        int32_t k, int32_t sorted,
+        int32_t m, int32_t n, double *a, 
+        int32_t ldA, int32_t k,
         double *top_values, int32_t *top_indices
     ) {
-        rindow_matlib_d_top_k(m, n, a, ldA, k, sorted, top_values, top_indices);
+        rindow_matlib_d_top_k(m, n, a, ldA, k, top_values, top_indices);
     }
 };
 
@@ -36,7 +36,6 @@ TYPED_TEST(TopKTest, normal) {
     const int32_t n = 5; // Number of columns or elements in each vector
     const int32_t ldA = n; // Leading dimension of the input
     const int32_t k = 3; // Number of top elements to find
-    const int32_t sorted = 1; // Return sorted values and indices
 
     TypeParam a[m][n] = {
         {1.0, 2.0, 3.0, 4.0, 5.0},
@@ -46,7 +45,7 @@ TYPED_TEST(TopKTest, normal) {
     TypeParam top_values[m][k];
     int32_t top_indices[m][k];
 
-    this->test_matlib_top_k(m, n, (TypeParam*)a, ldA, k, sorted, (TypeParam*)top_values, (int32_t*)top_indices);
+    this->test_matlib_top_k(m, n, (TypeParam*)a, ldA, k, (TypeParam*)top_values, (int32_t*)top_indices);
 
     // Expected results
     TypeParam expected_values[m][k] = {


### PR DESCRIPTION
This pull request introduces the `top_k` function for `double` and `float` data types in the `rindow-matlib` library in form of `rindow_matlib_s_top_k` and `rindow_matlib_d_top_k`. The function is inspired by TensorFlow's `tf.math.top_k` and calculates the top K values and indices of the K largest entries. Just like the softmax, it typically works with 2-dimensional matrices

## Key Features:
- **Top K Calculation**: The function identifies the top K values and their corresponding indices in the last dimension of 2-dimensional matrices.
- **Support for `double` and `float`**: Works with both `double` and `float` data types to accommodate a variety of use cases.
- **Parallel Processing**: Utilizes OpenMP for parallel processing, optimizing performance for larger datasets.
- **Sorted Results**: The function provides sorted results if requested, ensuring easy access to the top K values and indices.
- **Tests**: Added new tests for the new functions.

## Use Cases:
- Commonly used in machine learning tasks, such as analyzing model outputs and selecting the top K predictions.
- Helpful for data processing and feature engineering tasks that require ranking and selecting top entries.

I believe this function will be a valuable addition to the library, offering users a convenient and efficient way to calculate top K values and indices for their datasets. If this is merged, then I will go ahead and implement a similar functionality for the `PHPMath` class in `rindow/rindow-math-matrix` and subsequently the `LinearAlgebra` and  `MatrixOperator` classes. 

Please review the implementation and let me know if there are any suggestions or improvements. Thank you!
